### PR TITLE
entry de barcode se limpia en cambio a manual

### DIFF
--- a/Transferencias/Views/Almacen/AlmacenNuevaTransferenciaView.xaml.cs
+++ b/Transferencias/Views/Almacen/AlmacenNuevaTransferenciaView.xaml.cs
@@ -243,6 +243,7 @@ public partial class AlmacenNuevaTransferenciaView
         try { await CameraView.StopCameraAsync(); } catch { /* ignora si ya est� detenida */ }
         CameraLayer.IsVisible = false;
         ManualLayer.IsVisible = true;
+        BarcodeEntry.Text = string.Empty;
         BarcodeEntry.Focus();
     }
 

--- a/Transferencias/Views/Produccion/ProduccionCargaSolicitudView.xaml.cs
+++ b/Transferencias/Views/Produccion/ProduccionCargaSolicitudView.xaml.cs
@@ -190,6 +190,7 @@ public partial class ProduccionCargaSolicitudView
         try { await CameraView.StopCameraAsync(); } catch { /* ignora si ya est� detenida */ }
         CameraLayer.IsVisible = false;
         ManualLayer.IsVisible = true;
+        BarcodeEntry.Text = string.Empty;
         BarcodeEntry.Focus();
     }
 


### PR DESCRIPTION
se corrigió un error en el cual, si por error se utilizaba el escáner de código de barras integrado en vez de la cámara, el entry de barcode se modificaba igualmente, y al cambiar a modo manual, este quedaba con el texto anteriormente leído y no se limpiaba, realentizando la operatoria.
ahora al cambiar a manual el entry se limpia automáticamente para evitar esto.